### PR TITLE
Fix fitness overflow

### DIFF
--- a/evolution.py
+++ b/evolution.py
@@ -23,7 +23,10 @@ def evolve(n, butterflies, objective):
     cv.imwrite(path, result_img)
 
 def fitness_function(objective: Butterfly, candidate: Butterfly):
-    mse = -np.mean((objective - candidate) ** 2)
+
+    objective_f = objective.astype(np.float32)
+    candidate_f = candidate.astype(np.float32)
+    mse = -np.mean((objective_f - candidate_f) ** 2)
     return mse
 
 def evaluate(butterflies: list[Butterfly], objective: Butterfly):


### PR DESCRIPTION
## Summary
- fix overflow in fitness_function by converting images to float
- remove explanatory comments

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686042704d808328b6d97be1bda0047a